### PR TITLE
Add AoU LD pipeline (VAT prep, LD MatrixTable, LD matrix/scores)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Python build artifacts
+build/
+dist/
+*.egg-info
+
+# Python bytecode
+__pycache__/
+*.py[cod]
+
+# Hail driver logs
+hail-*.log
+
+# macOS
+.DS_Store

--- a/v8/analysis/generate_ld_data_from_aou_vds.py
+++ b/v8/analysis/generate_ld_data_from_aou_vds.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""
+All of Us LD pipeline from a Hail VDS (sparse variant_data → hom-ref filled MT → LD prune / matrix / scores).
+
+Variant filtering uses the **Variant Annotation Table (VAT)** ancestry-specific GVS fields when
+``--use-vat-callrate`` is set (default): per-ancestry ``gvs_<gen_anc>_an`` / (2 × N) as call rate on
+autosomes/PAR, where N is the per-ancestry diploid sample count from
+``ld_methods.ANCESTRY_PRED_OTHER_SAMPLE_COUNTS`` (see ``process_vat_for_ld`` in ``ld_methods``).
+Cohort genotypes are restricted to samples present in ``META_HT_PATH`` (filtered by ``--gen-anc``).
+VAT schema and field definitions:
+https://support.researchallofus.org/hc/en-us/articles/4615256690836-Variant-Annotation-Table
+
+Relevant VAT fields (not transcript-specific): ``gvs_<pop>_ac``, ``gvs_<pop>_an``, ``gvs_<pop>_af``,
+``gvs_<pop>_sc`` for computed ancestries afr, amr, eas, eur, mid, sas, oth (plus ``gvs_all_*``).
+Rows are variant×transcript; we collapse to one row per (locus, alleles).
+
+Design notes (aligned with v8/analysis/gnomad_ld_v4.py):
+- Read VDS, optionally filter chromosomes, filter_samples to analysis cohort (meta HT).
+- Work from vds.variant_data; row-level ``pop_freq`` for LD still comes from hl.agg.call_stats on
+  the filtered cohort MT after VAT row filter.
+- With VAT: keep variants passing ancestry call rate from ``gvs_<pop>_an``; without VAT, use in-VDS
+  cohort_callrate from call_stats only.
+- Optionally require PASS rows when ``filters`` exists (len(filters)==0).
+- Checkpoint variant_data intermediate (gnomAD-style), then unfilter_entries + hom-ref fill.
+- Optional ``--adj``: gnomAD-style filter **after** hom-ref fill; imputed hom-ref gaps
+  (hom-ref ``GT`` with missing ``GQ``) stay passable because they have no stored quality data.
+
+This is **step 1 of 2**. It writes the LD-ready cohort MatrixTable; LD prune / matrix / scores are
+step 2, in ``run_ld_from_aou_ld_mt.py``. Both derive their default MT path from ``MY_BUCKET``, so
+those two constants must stay in sync. Build the VAT first with ``generate_vat_for_ld.py``.
+
+Example:
+  python generate_ld_data_from_aou_vds.py --batch --gen-anc eas --contig chr22 \\
+    --generate-ld-mt --min-call-rate 0.9 --vat-path gs://bucket/vat/aou_v8_vat_table.ht \\
+    --output-prefix gs://bucket/ld/eas_chr22 --overwrite
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Optional
+
+import hail as hl
+from hail.utils.misc import new_temp_file
+
+from v8.analysis.ld_methods import (
+    ANCESTRY_PRED_OTHER_SAMPLE_COUNTS,
+    get_adj_expr as get_adj_expr_aou,
+    get_aou_variant_data,
+    gen_anc_to_vat_gvs_prefix,
+    process_vat_for_ld,
+)
+
+logger = logging.getLogger("aou_ld_from_vds")
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Emit INFO logs to stdout so they land in Dataproc/Batch driver output.
+
+    Without this, ``logger.setLevel`` alone leaves the root logger without a handler and every
+    progress message in this script is silently dropped.
+    """
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+        stream=sys.stdout,
+        force=True,
+    )
+    logger.setLevel(level)
+
+# ---------------------------------------------------------------------------
+# Paths and LD frequency defaults (gnomAD LD resources style)
+# ---------------------------------------------------------------------------
+
+GEN_ANC_PATH = "gs://fc-aou-datasets-controlled/v8/wgs/short_read/snpindel/aux/ancestry/ancestry_preds.tsv"
+VDS_PATH = "gs://fc-aou-datasets-controlled/v8/wgs/short_read/snpindel/vds/hail.vds"
+META_HT_PATH = "gs://aou_analysis/v8/data/utils/aou_v8_sample_meta.ht"
+
+VAT_HT_PATH = "gs://aou_marten/ld_data/vat/aou_v8_vat_table.ht"
+
+
+# Hail scratch (short retention is fine; these are throwaway intermediates).
+TMP_BUCKET = "gs://aou_tmp/ld_marten"
+# Pipeline outputs. MUST match MY_BUCKET in run_ld_from_aou_ld_mt.py, which derives its default
+# --ld-mt-path from it: a mismatch means step 2 looks for an MT step 1 never wrote there.
+MY_BUCKET = "gs://aou_tmp_30_days/ld_marten"
+
+def annotate_adj_ld(
+    mt: hl.MatrixTable,
+    adj_gq: int = 30,
+    adj_ab: float = 0.2,
+) -> hl.MatrixTable:
+    """gnomAD-style ``adj`` for LD after :func:`fill_missing_gt_hom_ref`.
+
+    Hom-ref cells with **missing** ``GQ`` pass ``adj`` in addition to the usual ``get_adj_expr`` rule.
+    Those are the sparse matrix gaps filled with hom-ref, which have no stored quality scores; the
+    strict rule (GQ ≥ threshold) would drop them all. Real hom-ref calls with non-missing low ``GQ``
+    still fail the strict branch.
+    """
+    if "GT" not in mt.entry and "LGT" in mt.entry:
+        gt_expr = mt.LGT
+    else:
+        gt_expr = mt.GT
+    if "AD" not in mt.entry and "LAD" in mt.entry:
+        ad_expr = mt.LAD
+    else:
+        ad_expr = mt.AD
+    strict = get_adj_expr_aou(gt_expr, mt.GQ, ad_expr, adj_gq, adj_ab)
+    imputed_hom_ref_gap = gt_expr.is_hom_ref() & hl.is_missing(mt.GQ)
+    # Missing strict (e.g. het with missing GQ) must be False, not missing, or filter_entries drops it.
+    return mt.annotate_entries(adj=hl.coalesce(strict, False) | imputed_hom_ref_gap)
+
+
+def fill_missing_gt_hom_ref(mt: hl.MatrixTable) -> hl.MatrixTable:
+    """Pseudo-dense-ify genotype calls for LD: restore filtered (sparse) entries, then set missing GT to hom-ref.
+
+    VDS variant_data is sparse: many sample×variant pairs have no stored call. ``unfilter_entries``
+    brings those cells back into the matrix; any still-missing ``GT`` is filled with ``0/0`` so downstream
+    LD (correlations, pruning) sees a complete diploid call matrix.
+
+    ASSUMPTION: restored calls are hom-ref, or enough are hom-ref to be confident in our LD evaluation.
+
+    Args:
+        mt: Matrix table whose entries include ``GT`` (typically AoU ``variant_data`` after cohort filters).
+
+    Returns:
+        Same schema with every entry row present; ``GT`` is never missing (hom-ref where it was absent).
+    """
+    logger.info("Starting fill_missing_gt_hom_ref")
+    mt = mt.unfilter_entries()
+    return mt.annotate_entries(
+        GT=hl.if_else(
+            hl.is_missing(mt.GT),
+            hl.if_else(mt.locus.in_autosome_or_par(), hl.call(0, 0), hl.call(0)),
+            mt.GT,
+        )
+    )
+
+
+def generate_ld_mt_from_vds(
+    vds_path: str,
+    meta_ht: hl.Table,
+    gen_anc: str,
+    contig: Optional[str],
+    min_call_rate: float,
+    ld_mt_path: str,
+    overwrite: bool,
+    adj: bool,
+    naive_coalesce: Optional[int],
+    vat_table: Optional[hl.Table],
+    recalculate_callrate_on_other: bool = False,
+) -> hl.MatrixTable:
+    """
+    gnomAD-style: read VDS → filter samples → checkpoint variant_data → row filters
+    (VAT ancestry ``gvs_*_an`` call rate and/or in-VDS call_stats) → hom-ref fill
+    → optional LD ``adj`` (:func:`annotate_adj_ld`) → checkpoint LD MT.
+
+    ``adj`` runs **after** fill so every cell has ``GT``; :func:`annotate_adj_ld` extends the usual
+    gnomAD rule so hom-ref with **missing** ``GQ`` (imputed sparse gaps) can pass, while real calls
+    with defined low ``GQ`` or bad het balance still fail.
+    """
+
+    gen_anc_key = gen_anc_to_vat_gvs_prefix(gen_anc)
+    gen_anc_threshold_str = (
+        f"gvs_{gen_anc_key}_callrate_threshold_{str(min_call_rate)}"
+    )
+    gen_anc_callrate = f"gvs_{gen_anc_key}_callrate"
+
+    gen_anc_af_str = f"gvs_{gen_anc_key}_af"
+    gen_anc_an_str = f"gvs_{gen_anc_key}_an"
+    gen_anc_ac_str = f"gvs_{gen_anc_key}_ac"
+
+    if contig:
+        vat_table = vat_table.filter(vat_table.locus.contig == contig)
+    else:
+        logger.info("No --contig provided; using all contigs from VAT and VDS.")
+
+    if recalculate_callrate_on_other:
+
+        logger.info(
+            "Recalculating %s call rate using ANCESTRY_PRED_OTHER_SAMPLE_COUNTS denominator",
+            gen_anc_key,
+        )
+
+        sample_count_with_other_correction = ANCESTRY_PRED_OTHER_SAMPLE_COUNTS[
+            gen_anc_key
+        ]
+
+        callrate_fields = {
+            gen_anc_callrate: hl.if_else(
+                vat_table.in_autosome_or_par,
+                vat_table[f"gvs_{gen_anc_key}_an"]
+                / hl.literal(float(sample_count_with_other_correction * 2)),
+                vat_table[f"gvs_{gen_anc_key}_an"]
+                / hl.literal(float(sample_count_with_other_correction)),
+            )
+        }
+        vat_table = vat_table.annotate(**callrate_fields)
+
+        callrate_threshold_fields = {
+            gen_anc_threshold_str: vat_table[gen_anc_callrate] >= min_call_rate
+        }
+        vat_table = vat_table.annotate(**callrate_threshold_fields)
+
+    # Fail loudly if the VAT was built with a different --min-call-rate: the threshold value is
+    # baked into the field name, so a mismatch would otherwise surface as an opaque Hail
+    # "no field" error deep in the query.
+    if gen_anc_threshold_str not in vat_table.row:
+        available = sorted(
+            f for f in vat_table.row if "_callrate_threshold_" in f
+        )
+        raise ValueError(
+            f"VAT table has no field {gen_anc_threshold_str!r} (implied by "
+            f"--min-call-rate {min_call_rate} and --gen-anc {gen_anc}). "
+            f"Threshold fields present: {available or 'none'}. "
+            "Rebuild the VAT with generate_vat_for_ld.py --min-call-rate "
+            f"{min_call_rate}, or pass --recalculate-callrate-on-other to derive it here."
+        )
+
+    vat_table = vat_table.filter(vat_table[f"{gen_anc_threshold_str}"])
+
+    entries_to_keep = ["GT"]
+
+    if adj:
+        entries_to_keep.append("GQ")
+        entries_to_keep.append("LAD")
+
+    vmt = get_aou_variant_data(
+        split=True,
+        filter_samples_ht=meta_ht,
+        filter_variant_ht=vat_table,
+        chrom=[contig] if contig else None,
+        naive_coalesce_partitions=naive_coalesce,
+        entries_to_keep=entries_to_keep,
+        checkpoint_variant_data=False,
+        vds_path=vds_path,
+    )
+
+    logger.info("checkpoint variant_data (gnomAD-style temp)")
+
+    count_outs = vmt.count()
+    if count_outs[0] == 0:
+        raise ValueError(
+            f"No variants in VDS after VAT filter for gen_anc={gen_anc} and contig={contig}"
+        )
+    if count_outs[1] == 0:
+        raise ValueError(
+            f"No samples in VDS after meta filter for gen_anc={gen_anc} and contig={contig}"
+        )
+
+    vmt = vmt.checkpoint(new_temp_file("aou_vds_variant", "mt"))
+
+    vmt = vmt.annotate_rows(
+        gen_anc_af=vat_table[vmt.row_key][f"{gen_anc_af_str}"],
+        gen_anc_an=vat_table[vmt.row_key][f"{gen_anc_an_str}"],
+        gen_anc_ac=vat_table[vmt.row_key][f"{gen_anc_ac_str}"],
+        gen_anc_callrate=vat_table[vmt.row_key][f"{gen_anc_callrate}"],
+    )
+
+    # No need to filter rows based on call rate since we are using the filtered VAT table
+
+    logger.info("unfilter_entries + hom-ref fill → GT")
+    vmt = fill_missing_gt_hom_ref(vmt)
+
+    if adj:
+        logger.info("annotate_adj_ld + filter_entries (after hom-ref fill)")
+        vmt = annotate_adj_ld(vmt)
+        vmt = vmt.filter_entries(vmt.adj)
+        vmt = vmt.select_entries("GT")
+
+    logger.info("checkpoint LD MT intermediate (pre-callstats)")
+    # vmt = vmt.checkpoint(new_temp_file("aou_ld_mt.pre_callstats", "mt"))
+
+    logger.info("Recomputing cohort call_stats into row field gen_anc_freq")
+    vmt = vmt.annotate_rows(gen_anc_freq=hl.agg.call_stats(vmt.GT, vmt.alleles))
+
+    logger.info("checkpoint LD MT → %s", ld_mt_path)
+    vmt = vmt.checkpoint(ld_mt_path, overwrite=overwrite)
+
+    return vmt
+
+
+def main(args) -> None:
+    configure_logging()
+
+    gen_anc = args.gen_anc
+    contig = args.contig
+    if args.test and not contig:
+        contig = "chr22"
+
+    if args.batch:
+        hl.init(
+            backend="batch",
+            tmp_dir=args.tmp_dir,
+            driver_memory="highmem",
+            driver_cores=8,
+            worker_memory="standard",
+            worker_cores=8,
+            default_reference="GRCh38",
+            log="/aou_ld_from_vds.log",
+            app_name="aou_ld_from_vds",
+            gcs_requester_pays_configuration=args.requester_pays,
+        )
+    elif args.dataproc:
+        hl.init(
+            tmp_dir=args.tmp_dir,
+            default_reference="GRCh38",
+            app_name="aou_ld_from_vds",
+            gcs_requester_pays_configuration=args.requester_pays,
+            backend="spark",
+        )
+    else:
+        raise ValueError(
+            "Must run in batch or dataproc mode. Please set --batch or --dataproc."
+        )
+
+    hl._set_flags(use_new_shuffle="1")
+
+    # Read (or build) the Variant Annotation Table used to filter to LD-eligible variants.
+    # Prefer building it with generate_vat_for_ld.py and passing --vat-path here; --do-generate-vat
+    # rebuilds it inline, which repeats expensive work on every LD run.
+    vat_path = args.vat_path or VAT_HT_PATH
+
+    vat_table = None
+    if args.do_generate_vat:
+        logger.info("Building VAT inline and checkpointing to %s", vat_path)
+        vat_table = process_vat_for_ld(
+            callrate_threshold=args.min_call_rate,
+            contig=contig,
+        )
+        vat_table = vat_table.checkpoint(vat_path, overwrite=args.overwrite)
+
+    if vat_table is None:
+        logger.info("Reading VAT from %s", vat_path)
+        vat_table = hl.read_table(vat_path)
+
+    # Read in Wenhan's generated sample meta HT. Used to to filter to samples.
+    meta_ht = hl.read_table(META_HT_PATH)
+    gen_anc_upper = gen_anc.upper()
+
+    # Wenhan's table is capitalized.
+    meta_ht_filter = meta_ht.filter(meta_ht.ancestry == gen_anc_upper)
+    if meta_ht_filter.count() == 0:
+        raise ValueError(f"No samples in meta for gen_anc={gen_anc}")
+
+    # Note that we do not read in the VDS here.
+
+    # Default output prefix and defining some paths.
+    output_prefix = (
+        args.output_prefix or f"{MY_BUCKET}/{gen_anc}_{contig or 'genome'}_vdsld"
+    )
+
+    custom_suffix = args.custom_suffix or ""
+    suffix_token = f"_{custom_suffix}" if custom_suffix else ""
+    ld_mt_path = args.ld_mt_path or f"{output_prefix}_ld_cohort{suffix_token}.mt"
+
+    if args.generate_ld_mt:
+        generate_ld_mt_from_vds(
+            vds_path=args.vds_path or VDS_PATH,
+            meta_ht=meta_ht_filter,
+            gen_anc=gen_anc,
+            contig=contig,
+            min_call_rate=args.min_call_rate,
+            ld_mt_path=ld_mt_path,
+            overwrite=args.overwrite,
+            adj=args.adj,
+            naive_coalesce=args.naive_coalesce,
+            vat_table=vat_table,
+            recalculate_callrate_on_other=args.recalculate_callrate_on_other,
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="AoU VDS → cohort LD MatrixTable"
+    )
+    parser.add_argument("--gen-anc", default="eas", help="Cohort pop / meta_ht.pop")
+    parser.add_argument(
+        "--contig", default=None, help="Restrict to one chrom (e.g. chr22)"
+    )
+    parser.add_argument(
+        "--vds-path",
+        default=None,
+        help=f"VDS URI (default: ld_methods.VDS_PATH = {VDS_PATH})",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default=None,
+        help="Prefix for pruned/index/bm/ldscores paths and default LD MT name",
+    )
+    parser.add_argument(
+        "--ld-mt-path",
+        default=None,
+        help="Checkpoint path for cohort LD MatrixTable",
+    )
+    parser.add_argument(
+        "--min-call-rate",
+        dest="min_call_rate",
+        type=float,
+        default=0.90,
+        help=(
+            "Minimum call rate (0–1) used for VAT callrate-threshold filtering."
+        ),
+    )
+    parser.add_argument(
+        "--generate-ld-mt",
+        action="store_true",
+        help="Read VDS, filter, call-stats, hom-ref fill, checkpoint LD MT",
+    )
+
+    parser.add_argument(
+        "--adj",
+        action="store_true",
+        help="Keep ADJ genotypes only (needs GQ/DP/AD entries)",
+    )
+    parser.add_argument(
+        "--naive-coalesce",
+        type=int,
+        default=None,
+        help="Coalesce variant_data to N partitions before checkpoint",
+    )
+    parser.add_argument(
+        "--custom-suffix", default="", help="Suffix token in output paths"
+    )
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--dataproc", action="store_true")
+    parser.add_argument(
+        "--batch",
+        action="store_true",
+        help="Run the pipeline in QueryOnBatch, not Dataproc.",
+    )
+    parser.add_argument(
+        "--test", action="store_true", help="Use chr22 if --contig not set"
+    )
+    parser.add_argument("--tmp-dir", default=TMP_BUCKET)
+    parser.add_argument(
+        "--vat-path",
+        default=None,
+        help=(
+            "Processed VAT Hail table to filter variants with, as written by "
+            f"generate_vat_for_ld.py (default: {VAT_HT_PATH}). For a single-contig VAT, point "
+            "this at e.g. .../aou_v8_vat_table_chr1.ht."
+        ),
+    )
+    parser.add_argument(
+        "--do-generate-vat",
+        action="store_true",
+        help=(
+            "Build the VAT inline and checkpoint it to --vat-path before running. Prefer "
+            "generate_vat_for_ld.py; this repeats expensive work on every LD run."
+        ),
+    )
+    parser.add_argument(
+        "--requester-pays",
+        default="aou-neale-gwas",
+        help="GCS requester pays project",
+    )
+    parser.add_argument(
+        "--recalculate-callrate-on-other",
+        action="store_true",
+        help="Recalculate call rate on samples with correction for samples labeled as other in ancestry prediction",
+    )
+
+    args = parser.parse_args()
+
+    main(args)

--- a/v8/analysis/generate_vat_for_ld.py
+++ b/v8/analysis/generate_vat_for_ld.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""
+Generate the AoU Variant Annotation Table (VAT) Hail table used to filter variants for LD.
+
+Supersedes ``generate_vat_chr1.py``, which was hardcoded to one chromosome. The processing
+itself is unchanged and lives in :func:`v8.analysis.ld_methods.process_vat_for_ld`: import the
+controlled-release VAT TSV, cast the string numeric columns, key by ``(locus, alleles)``,
+collapse the variant x transcript duplicates with ``distinct()``, then annotate per-ancestry
+``gvs_<anc>_callrate`` and ``gvs_<anc>_callrate_threshold_<value>`` flags.
+
+Two modes:
+
+``--mode single``
+    One ``import_table`` pass over the whole VAT, one output table. Fewer, larger jobs.
+
+``--mode serial``
+    Loop contigs, writing one table per contig. Each contig is an independent write, so a
+    failure costs one contig instead of the whole genome, and completed contigs are skipped on
+    re-run (see ``--reuse-existing``). Add ``--union`` to also concatenate the per-contig
+    tables into a single genome-wide table at the end.
+
+Which mode to use: the expensive step is ``distinct()``, which shuffles the full
+variant x transcript row set. Serial mode shrinks that shuffle to roughly one chromosome's
+worth of rows, which is the difference between fitting in worker memory and not. The cost is
+that ``hl.import_table`` re-scans and re-decompresses the entire single-file bgz TSV once per
+contig -- serial mode does N times the import I/O of single mode. Prefer ``single`` if it
+completes; fall back to ``serial`` when the genome-wide shuffle is the thing that fails.
+
+NOTE ON FIELD NAMES: the threshold flag embeds the float, e.g. ``gvs_eur_callrate_threshold_0.9``.
+The ``.`` means Hail attribute access does not work -- use ``ht['gvs_eur_callrate_threshold_0.9']``,
+not ``ht.gvs_eur_callrate_threshold_0.9``. Keep ``--min-call-rate`` consistent with the value
+passed to ``generate_ld_data_from_aou_vds.py``, which reconstructs this field name to filter rows.
+
+VAT schema:
+https://support.researchallofus.org/hc/en-us/articles/4615256690836-Variant-Annotation-Table
+
+Examples:
+  # One genome-wide table (Query on Batch)
+  python generate_vat_for_ld.py --batch --mode single --overwrite
+
+  # Per-contig tables, resumable, plus a unioned genome-wide table
+  python generate_vat_for_ld.py --dataproc --mode serial --union --overwrite
+
+  # Just chr1, matching the legacy generate_vat_chr1.py output path
+  python generate_vat_for_ld.py --batch --mode serial --contigs chr1 --overwrite
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import List, Optional
+
+import hail as hl
+
+from v8.analysis.ld_methods import (
+    ANCESTRY_PRED_OTHER_SAMPLE_COUNTS,
+    VAT_PATH,
+    process_vat_for_ld,
+)
+
+logger = logging.getLogger("generate_vat_for_ld")
+
+# ---------------------------------------------------------------------------
+# Paths and defaults
+# ---------------------------------------------------------------------------
+
+# Output root and basename chosen so per-contig output matches the table already written by the
+# legacy generate_vat_chr1.py: gs://aou_marten/ld_data/vat/aou_v8_vat_table_chr1.ht
+DEFAULT_OUTPUT_ROOT = "gs://aou_marten/ld_data/vat"
+DEFAULT_BASENAME = "aou_v8_vat_table"
+TMP_BUCKET = "gs://aou_tmp/ld_marten"
+
+# GRCh38 primary contigs. chrM is excluded by default: LD on the mitochondrion is not
+# meaningful, and it is not autosome-or-PAR so it would take the haploid callrate denominator.
+# Pass it explicitly via --contigs if you want it.
+DEFAULT_CONTIGS = [f"chr{i}" for i in range(1, 23)] + ["chrX", "chrY"]
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Emit INFO logs to stdout so they land in Dataproc/Batch driver output."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+        stream=sys.stdout,
+        force=True,
+    )
+    logger.setLevel(level)
+
+
+def vat_ht_path(output_root: str, basename: str, contig: Optional[str] = None) -> str:
+    """Output URI for the whole-genome table (``contig=None``) or one contig."""
+    suffix = f"_{contig}" if contig else ""
+    return f"{output_root}/{basename}{suffix}.ht"
+
+
+def _write_completed(path: str) -> bool:
+    """True if ``path`` looks like a fully written Hail table.
+
+    Checks for the ``_SUCCESS`` marker rather than the directory itself, so a partially written
+    table left behind by a killed job is not mistaken for a finished one.
+    """
+    try:
+        return hl.hadoop_exists(f"{path}/_SUCCESS")
+    except Exception as e:  # noqa: BLE001 - unreadable path is treated as "not written"
+        logger.warning("Could not stat %s (%s); treating as not written", path, e)
+        return False
+
+
+def generate_vat(
+    contig: Optional[str],
+    output_path: str,
+    vat_path: str,
+    callrate_threshold: float,
+    overwrite: bool,
+) -> hl.Table:
+    """Process the VAT (optionally for one contig) and write it to ``output_path``."""
+    logger.info(
+        "Processing VAT for %s -> %s", contig or "all contigs", output_path
+    )
+    vat_table = process_vat_for_ld(
+        n_samples_dict=ANCESTRY_PRED_OTHER_SAMPLE_COUNTS,
+        vat_path=vat_path,
+        callrate_threshold=callrate_threshold,
+        contig=contig,
+    )
+    vat_table = vat_table.checkpoint(output_path, overwrite=overwrite)
+    logger.info("Wrote %s (%s rows)", output_path, vat_table.count())
+    return vat_table
+
+
+def run_single(args: argparse.Namespace) -> None:
+    """One pass over the whole VAT, one genome-wide output table."""
+    out = args.output or vat_ht_path(args.output_root, args.basename)
+    if args.reuse_existing and _write_completed(out):
+        logger.info("%s already written; nothing to do (--reuse-existing)", out)
+        return
+    generate_vat(
+        contig=None,
+        output_path=out,
+        vat_path=args.vat_path,
+        callrate_threshold=args.min_call_rate,
+        overwrite=args.overwrite,
+    )
+
+
+def run_serial(args: argparse.Namespace, contigs: List[str]) -> None:
+    """One output table per contig, then optionally union them into one table."""
+    written: List[str] = []
+    skipped: List[str] = []
+    failed: List[str] = []
+
+    for contig in contigs:
+        out = vat_ht_path(args.output_root, args.basename, contig)
+        if args.reuse_existing and _write_completed(out):
+            logger.info("Skipping %s: %s already written", contig, out)
+            skipped.append(contig)
+            written.append(out)
+            continue
+        try:
+            generate_vat(
+                contig=contig,
+                output_path=out,
+                vat_path=args.vat_path,
+                callrate_threshold=args.min_call_rate,
+                overwrite=args.overwrite,
+            )
+            written.append(out)
+        except Exception as e:  # noqa: BLE001 - keep going so one bad contig is not fatal
+            if not args.continue_on_error:
+                raise
+            logger.error("Contig %s FAILED: %s", contig, e)
+            failed.append(contig)
+
+    logger.info(
+        "Serial run done: %s written, %s reused, %s failed",
+        len(written) - len(skipped),
+        len(skipped),
+        len(failed),
+    )
+    if failed:
+        logger.error("Failed contigs (rerun with --reuse-existing to fill gaps): %s", failed)
+
+    if not args.union:
+        return
+    if failed:
+        raise ValueError(
+            f"Refusing to --union an incomplete set; these contigs failed: {failed}. "
+            "Rerun with --reuse-existing to fill the gaps, then --union."
+        )
+
+    union_out = args.output or vat_ht_path(args.output_root, args.basename)
+    logger.info("Unioning %s per-contig tables into %s", len(written), union_out)
+    # Contigs are processed in reference order and each table is keyed by (locus, alleles),
+    # so this concatenation is already key-sorted.
+    tables = [hl.read_table(p) for p in written]
+    unioned = tables[0] if len(tables) == 1 else tables[0].union(*tables[1:])
+    unioned = unioned.checkpoint(union_out, overwrite=args.overwrite)
+    logger.info("Wrote %s (%s rows)", union_out, unioned.count())
+
+
+def main(args: argparse.Namespace) -> None:
+    configure_logging()
+
+    contigs = args.contigs or DEFAULT_CONTIGS
+    if args.mode == "single" and args.contigs:
+        raise ValueError(
+            "--contigs only applies to --mode serial. For a contig subset in one table, run "
+            "--mode serial --contigs ... --union."
+        )
+    if args.union and args.mode != "serial":
+        raise ValueError("--union only applies to --mode serial.")
+
+    if args.batch:
+        hl.init(
+            backend="batch",
+            tmp_dir=args.tmp_dir,
+            driver_memory="highmem",
+            driver_cores=8,
+            worker_memory="standard",
+            worker_cores=8,
+            default_reference="GRCh38",
+            log="/generate_vat_for_ld.log",
+            app_name="generate_vat_for_ld",
+            gcs_requester_pays_configuration=args.requester_pays,
+        )
+    elif args.dataproc:
+        hl.init(
+            tmp_dir=args.tmp_dir,
+            default_reference="GRCh38",
+            app_name="generate_vat_for_ld",
+            gcs_requester_pays_configuration=args.requester_pays,
+            backend="spark",
+        )
+    else:
+        raise ValueError("Must run in batch or dataproc mode. Set --batch or --dataproc.")
+
+    hl._set_flags(use_new_shuffle="1")
+
+    if args.mode == "single":
+        run_single(args)
+    else:
+        logger.info("Serial mode over %s contigs: %s", len(contigs), contigs)
+        run_serial(args, contigs)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate the AoU VAT Hail table for LD variant filtering, either as one "
+            "genome-wide table (--mode single) or one table per contig (--mode serial)."
+        )
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["single", "serial"],
+        default="single",
+        help=(
+            "single: one pass over the whole VAT into one table. "
+            "serial: one table per contig, resumable, optionally unioned with --union. "
+            "(default: single)"
+        ),
+    )
+    parser.add_argument(
+        "--contigs",
+        nargs="+",
+        default=None,
+        metavar="CONTIG",
+        help=(
+            "Contigs for --mode serial (e.g. --contigs chr1 chr2 chrX). "
+            f"Default: {' '.join(DEFAULT_CONTIGS)}"
+        ),
+    )
+    parser.add_argument(
+        "--union",
+        action="store_true",
+        help=(
+            "After --mode serial, concatenate the per-contig tables into one genome-wide "
+            "table at --output (or the default whole-genome path)."
+        ),
+    )
+    parser.add_argument(
+        "--vat-path",
+        default=VAT_PATH,
+        help=f"URI of the AoU VAT TSV (default: {VAT_PATH})",
+    )
+    parser.add_argument(
+        "--output-root",
+        default=DEFAULT_OUTPUT_ROOT,
+        help=f"Directory for outputs (default: {DEFAULT_OUTPUT_ROOT})",
+    )
+    parser.add_argument(
+        "--basename",
+        default=DEFAULT_BASENAME,
+        help=(
+            "Output table basename; per-contig tables get a _<contig> suffix "
+            f"(default: {DEFAULT_BASENAME})"
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help=(
+            "Explicit path for the single/unioned genome-wide table. Overrides "
+            "--output-root/--basename. Does not affect per-contig paths."
+        ),
+    )
+    parser.add_argument(
+        "--min-call-rate",
+        dest="min_call_rate",
+        type=float,
+        default=0.90,
+        help=(
+            "Call-rate threshold baked into the gvs_<anc>_callrate_threshold_<value> field "
+            "names. Must match the --min-call-rate passed to generate_ld_data_from_aou_vds.py. "
+            "(default: 0.90 -> field suffix '0.9')"
+        ),
+    )
+    parser.add_argument(
+        "--reuse-existing",
+        action="store_true",
+        help=(
+            "Skip any output whose _SUCCESS marker already exists. Use this to resume an "
+            "interrupted serial run without recomputing finished contigs."
+        ),
+    )
+    parser.add_argument(
+        "--continue-on-error",
+        action="store_true",
+        help=(
+            "In serial mode, log and continue past a failing contig instead of aborting. "
+            "--union will still refuse to run if any contig failed."
+        ),
+    )
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--dataproc", action="store_true")
+    parser.add_argument(
+        "--batch",
+        action="store_true",
+        help="Run in Query on Batch (recommended)",
+    )
+    parser.add_argument("--tmp-dir", default=TMP_BUCKET)
+    parser.add_argument(
+        "--requester-pays",
+        default="aou-neale-gwas",
+        help="GCS requester-pays project",
+    )
+
+    main(parser.parse_args())

--- a/v8/analysis/ld_methods.py
+++ b/v8/analysis/ld_methods.py
@@ -1,0 +1,407 @@
+"""
+All of Us LD helpers: VAT (GVS) tables for ancestry filters, and VDS ``variant_data`` loading
+with optional multiallelic splitting via ``hl.experimental.sparse_split_multi``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, List, Union, Set
+
+import hail as hl
+from hail.utils.misc import new_temp_file
+
+
+logger = logging.getLogger("aou_ld_methods")
+logger.setLevel(logging.INFO)
+
+VDS_PATH = "gs://fc-aou-datasets-controlled/v8/wgs/short_read/snpindel/vds/hail.vds"
+
+
+def get_adj_expr(
+    gt_expr: hl.expr.CallExpression,
+    gq_expr: Union[hl.expr.Int32Expression, hl.expr.Int64Expression],
+    ad_expr: hl.expr.ArrayNumericExpression,
+    adj_gq: int = 30,
+    adj_ab: float = 0.2,
+) -> hl.expr.BooleanExpression:
+    """
+    Get adj genotype annotation. Defaults correspond to gnomAD values.
+
+    Verbatim copy of ``get_adj_expr`` in ``v8/data_prep/process_data.py`` (author: wlu).
+    Duplicated deliberately: importing that module executes ``from gnomad.utils.vep import *``,
+    ``hailtop.batch``, ``pandas`` and ``tqdm`` at load time, so the LD pipeline would need the
+    full GWAS dependency set just to build this one expression. Keep in sync if the upstream
+    definition changes.
+    """
+    return (gq_expr >= adj_gq) & (
+        hl.case()
+        .when(~gt_expr.is_het(), True)
+        .when(gt_expr.is_het_ref(), ad_expr[gt_expr[1]] / hl.sum(ad_expr) >= adj_ab)
+        .default(
+            (ad_expr[gt_expr[0]] / hl.sum(ad_expr) >= adj_ab)
+            & (ad_expr[gt_expr[1]] / hl.sum(ad_expr) >= adj_ab)
+        )
+    )
+
+AUX_PATH = "gs://fc-aou-datasets-controlled/v8/wgs/short_read/snpindel/aux"
+VAT_PATH = f'{AUX_PATH}/vat/vat_complete.bgz.tsv.gz'
+
+# We are not calculating LD on OTH. 
+VAT_GVS_ANCESTRY_CODES = frozenset({"afr", "amr", "eas", "eur", "mid", "sas"})
+
+META_GEN_ANC_SAMPLE_COUNTS = {'afr': 77444,
+    'amr': 71540,
+    'eas': 9488,
+    'eur': 227273,
+    'mid': 1153,
+    'sas': 5132}
+
+ANCESTRY_PRED_OTHER_SAMPLE_COUNTS = {'afr': 79826,
+ 'amr': 71854,
+ 'eas': 9440,
+ 'eur': 223350,
+ 'mid': 810,
+ 'oth': 25504,
+ 'sas': 4046}
+
+
+def gen_anc_to_vat_gvs_prefix(gen_anc: str) -> str:
+    """
+    Map a genetic-ancestry code to the VAT ``gvs_<pop>_*`` column prefix.
+
+    :param gen_anc: Short code (e.g. ``eas``, ``afr``) matching ``VAT_GVS_ANCESTRY_CODES``.
+    :return: Lowercased ancestry token used in column names (e.g. ``eas`` → ``gvs_eas_an``).
+    :raises ValueError: If ``gen_anc`` is not a supported GVS ancestry.
+    """
+    g = gen_anc.strip().lower()
+    if g not in VAT_GVS_ANCESTRY_CODES:
+        raise ValueError(
+            f"gen_anc={gen_anc!r} has no GVS VAT fields; expected one of {sorted(VAT_GVS_ANCESTRY_CODES)}"
+        )
+    return g
+
+
+def _vat_str_to_int32(s: hl.expr.StringExpression) -> hl.expr.Int32Expression:
+    """Parse VAT TSV integer fields when ``import_table`` leaves them as strings."""
+    blank = hl.is_missing(s) | (s == "") | (s == ".") | (s == "NA")
+    return hl.if_else(blank, hl.missing(hl.tint32), hl.int32(s))
+
+
+def _vat_str_to_float64(s: hl.expr.StringExpression) -> hl.expr.Float64Expression:
+    """Parse VAT TSV float fields (e.g. AF) when stored as strings."""
+    blank = hl.is_missing(s) | (s == "") | (s == ".") | (s == "NA")
+    return hl.if_else(blank, hl.missing(hl.tfloat64), hl.float64(s))
+
+
+def process_vat_for_ld(
+    n_samples_dict: dict[str, int] = ANCESTRY_PRED_OTHER_SAMPLE_COUNTS,
+    vat_path: str = VAT_PATH,
+    callrate_threshold: float = 0.90,
+    test: bool = False,
+    contig: Optional[str] = None,
+) -> hl.Table:
+    """
+    Process an AoU Variant Annotation Table (Hail) for LD analysis.
+
+    :param vat_path: URI of the VAT TSV (``import_table`` without ``impute=True`` leaves
+        numeric columns as strings; those are cast to int/float before call-rate math).
+    :param n_samples_dict: Per-ancestry diploid sample count ``N`` per ancestry for
+        ``gvs_<anc>_callrate = gvs_<anc>_an / (2 * N)`` on autosomes/PAR (haploid sex
+        chromosomes use ``/ N``). Defaults to :data:`ANCESTRY_PRED_OTHER_SAMPLE_COUNTS`
+        (denominators aligned with ancestry prediction / “other” cohort sizes), not
+        :data:`META_GEN_ANC_SAMPLE_COUNTS`.
+    :param callrate_threshold: Minimum call rate threshold for variants. Becomes part of the
+        output field name: ``gvs_<anc>_callrate_threshold_<callrate_threshold>``.
+    :param test: Shorthand for ``contig="chr1"``. Ignored when ``contig`` is set.
+    :param contig: Keep only this contig (e.g. ``chr1``). ``None`` processes the whole VAT.
+        The filter is applied on the raw ``contig`` string column, before ``hl.locus`` is
+        built, so it costs nothing beyond the TSV scan.
+    :return: Keyed table joinable to ``variant_data`` on ``(locus, alleles)``.
+    """
+    vat_table = hl.import_table(vat_path, quote='"', delimiter="\t", force_bgz=True)
+
+    if contig is None and test:
+        contig = "chr1"
+    if contig is not None:
+        logger.info("Filtering VAT to contig %s", contig)
+        vat_table = vat_table.filter(vat_table.contig == contig)
+
+    vat_table = vat_table.annotate(
+        locus=hl.locus(vat_table.contig, _vat_str_to_int32(vat_table.position)),
+        alleles=hl.array([vat_table.ref_allele, vat_table.alt_allele]),
+    )
+
+    gvs_metric = ["ac", "an", "af", "sc"]
+    gvs_genanc = list(VAT_GVS_ANCESTRY_CODES) + ["max", "all"]
+
+    gvs_rows = [
+        f"gvs_{gvs_genanc_i}_{gvs_metric_i}"
+        for gvs_genanc_i in gvs_genanc
+        for gvs_metric_i in gvs_metric
+    ]
+
+    filter_rows = [
+        "locus",
+        "alleles",
+        "contig",
+        "position",
+        "ref_allele",
+        "alt_allele",
+    ] + gvs_rows
+
+    vat_table = vat_table.select(*filter_rows)
+
+    # ``import_table`` without ``impute=True`` leaves numeric VAT columns as strings; cast before math.
+    vat_table = vat_table.select(
+        vat_table.locus,
+        vat_table.alleles,
+        vat_table.contig,
+        vat_table.position,
+        vat_table.ref_allele,
+        vat_table.alt_allele,
+        **{
+            f"gvs_{g}_{m}": (
+                _vat_str_to_float64(vat_table[f"gvs_{g}_{m}"])
+                if m == "af"
+                else _vat_str_to_int32(vat_table[f"gvs_{g}_{m}"])
+            )
+            for g in gvs_genanc
+            for m in gvs_metric
+        },
+    )
+    
+    vat_table = vat_table.checkpoint(new_temp_file('locus_allele_vat',extension='ht'))
+    
+    vat_table = vat_table.key_by('locus','alleles')
+
+    # There is no difference between callstats for the same variant across different transcripts, so we can call distinct
+
+    vat_table = vat_table.distinct()
+
+    vat_table = vat_table.annotate(
+        in_autosome_or_par = vat_table.locus.in_autosome_or_par()
+    )
+
+    callrate_fields = {
+        f"gvs_{gen_anc}_callrate": hl.if_else(
+            vat_table.in_autosome_or_par,
+            vat_table[f"gvs_{gen_anc}_an"] / hl.literal(float(n_samples_dict[gen_anc] * 2)),
+            vat_table[f"gvs_{gen_anc}_an"] / hl.literal(float(n_samples_dict[gen_anc])),  # haploid sex chromosomes
+        )
+        for gen_anc in VAT_GVS_ANCESTRY_CODES
+    }
+
+    vat_table = vat_table.annotate(**callrate_fields)
+
+    callrate_threshold_fields = {
+        f"gvs_{gen_anc}_callrate_threshold_{str(callrate_threshold)}": vat_table[f"gvs_{gen_anc}_callrate"] >= callrate_threshold
+        for gen_anc in VAT_GVS_ANCESTRY_CODES
+    }
+    vat_table = vat_table.annotate(**callrate_threshold_fields)
+
+    return vat_table
+
+
+def _split_and_filter_variant_data_for_loading(
+    mt: hl.MatrixTable,
+    filter_variant_ht: Optional[hl.Table] = None,
+    entries_to_keep: Optional[List[str]] = None,
+    checkpoint_before_split: bool = False,
+) -> hl.MatrixTable:
+    """
+    Prepare sparse ``variant_data`` for splitting: optional entry subset, locus pre-filter,
+    row annotations, checkpoint, then ``hl.experimental.sparse_split_multi``.
+
+    Order of operations:
+
+    1. If ``entries_to_keep`` is set, select those fields (mapping ``GT``/``AD``/``PL`` to
+       ``LGT``/``LAD``/``LPL`` and always keeping ``LA``) before split.
+    2. If ``filter_variant_ht`` is set, restrict rows by **locus** only (sorted key-by
+       optimization), then annotate ``n_unsplit_alleles`` and ``mixed_site``.
+    3. Optional checkpoint (materialize before split).
+    4. ``sparse_split_multi(..., filter_changed_loci=True)``.
+    5. If ``filter_variant_ht`` is set, ``semi_join_rows`` to the full variant key table.
+
+    :param mt: Unsplit ``vds.variant_data`` MatrixTable.
+    :param filter_variant_ht: Optional table keyed by at least ``locus`` (first pass) and
+        by ``(locus, alleles)`` after split for ``semi_join_rows``.
+    :param entries_to_keep: Names of **global** entry fields to retain before split
+        (e.g. ``GT``); these are converted to local ``L*`` where required for splitting.
+    :param checkpoint_before_split: If True, checkpoint immediately before ``sparse_split_multi``.
+    :return: Split, biallelic-oriented ``variant_data`` MatrixTable.
+    """
+    if entries_to_keep is not None:
+        split_entries_to_keep = entries_to_keep + ["LA"]
+        split_entries_to_keep = [
+            "L" + e if e in {"GT", "AD", "PL"} else e for e in split_entries_to_keep
+        ]
+        mt = mt.select_entries(*split_entries_to_keep)
+
+    if filter_variant_ht is not None:
+        # Prevents hail from running sort on HT which is already sorted.
+        filter_locus_ht = hl.Table(
+            hl.ir.TableKeyBy(filter_variant_ht._tir, ["locus"], is_sorted=True)
+        )
+        mt = mt.filter_rows(hl.is_defined(filter_locus_ht[mt.locus]))
+
+    mt = mt.annotate_rows(
+        n_unsplit_alleles=hl.len(mt.alleles),
+        mixed_site=(hl.len(mt.alleles) > 2)
+        & hl.any(lambda a: hl.is_indel(mt.alleles[0], a), mt.alleles[1:])
+        & hl.any(lambda a: hl.is_snp(mt.alleles[0], a), mt.alleles[1:]),
+    )
+
+    if checkpoint_before_split:
+        mt = mt.checkpoint(new_temp_file("variant_data.before_split", "mt"))
+
+    logger.info("Splitting multiallelics...")
+    mt = hl.experimental.sparse_split_multi(mt, filter_changed_loci=True)
+
+    # Different considerations before splitting and after splitting.
+    # Note that this does not annotate relevant fields needed for later. 
+    if filter_variant_ht is not None:
+        mt = mt.semi_join_rows(filter_variant_ht)
+
+    return mt
+
+def get_aou_variant_data(
+    split: bool = False,
+    filter_samples_ht: Optional[hl.Table] = None,
+    n_partitions: Optional[int] = None,
+    filter_partitions: Optional[List[int]] = None,
+    chrom: Optional[Union[str, List[str], Set[str]]] = None,
+    filter_variant_ht: Optional[hl.Table] = None,
+    filter_intervals: Optional[List[Union[str, hl.tinterval]]] = None,
+    split_reference_blocks: bool = True,
+    entries_to_keep: Optional[List[str]] = None,
+    checkpoint_variant_data: bool = False,
+    naive_coalesce_partitions: Optional[int] = None,
+    vds_path: str = VDS_PATH,
+) -> hl.MatrixTable:
+    """
+    Load the AoU short-read WGS VDS and return the **variant_data** MatrixTable (sparse).
+
+    This function does **not** densify and does not return reference blocks; downstream
+    code should treat the result as sparse ``variant_data`` only.
+
+    :param split: If True, run :func:`_split_and_filter_variant_data_for_loading` (multiallelic split).
+    :param filter_samples_ht: Optional sample table passed to ``hl.vds.filter_samples`` (must match VDS column keys).
+    :param n_partitions: Subset partitions when reading (see ``n_partitions`` + ``chrom`` branch).
+    :param filter_partitions: Restrict to listed partition indices on both reference and variant MTs.
+    :param chrom: Contig(s) to keep (string or list); combined with ``autosomes_only`` / ``sex_chr_only``.
+    :param autosomes_only: Set ``chrom`` to all autosomes (GRCh38 reference genome).
+    :param sex_chr_only: Set ``chrom`` to X/Y contigs only.
+    :param filter_variant_ht: When ``split`` is True, forwarded to :func:`_split_and_filter_variant_data_for_loading`.
+        Requires ``split=True`` (raises otherwise).
+    :param filter_intervals: Genomic intervals for ``hl.vds.filter_intervals``.
+    :param split_reference_blocks: Passed through to ``filter_intervals``.
+    :param entries_to_keep: Global entry field names; if ``split`` is True, applied inside the split helper;
+        if ``split`` is False, ``select_entries`` is applied after loading.
+    :param checkpoint_variant_data: If True, passed as ``checkpoint_before_split`` to the split helper when
+        ``split`` is True; if True after that, checkpoints again after optional ``select_entries``.
+    :param naive_coalesce_partitions: ``naive_coalesce`` both reference and variant MTs before extraction.
+    :param vds_path: URI of the VDS to read (defaults to :data:`VDS_PATH`).
+    :return: The **variant_data** ``MatrixTable`` (optionally split and filtered).
+    :raises ValueError: If ``filter_variant_ht`` is set and ``split`` is False.
+    """
+
+    if filter_variant_ht is not None and split is False:
+        raise ValueError(
+            "Filtering to a specific set of variants is only supported when splitting"
+            " the VDS."
+        )
+
+    if isinstance(chrom, str):
+        chrom = [chrom]
+
+    # This is not a use case for us actually, since we are only doing single chromosomes at a time. 
+    # Removing autosomes_only and sex_chr_only. 
+    # This is not a use case for us actually, since we are only doing single chromosomes at a time. 
+    # Removing autosomes_only and sex_chr_only. 
+
+    if n_partitions and chrom:
+        logger.info(
+            "Filtering to chromosome(s) %s with %s partitions...", chrom, n_partitions
+        )
+        reference_data = hl.read_matrix_table(
+            hl.vds.VariantDataset._reference_path(vds_path)
+        )
+        reference_data = hl.filter_intervals(
+            reference_data,
+            [hl.parse_locus_interval(x, reference_genome="GRCh38") for x in chrom],
+        )
+        intervals = reference_data._calculate_new_partitions(n_partitions)
+        reference_data = hl.read_matrix_table(
+            hl.vds.VariantDataset._reference_path(vds_path),
+            _intervals=intervals,
+        )
+        variant_data = hl.read_matrix_table(
+            hl.vds.VariantDataset._variants_path(vds_path),
+            _intervals=intervals,
+        )
+        vds = hl.vds.VariantDataset(reference_data, variant_data)
+    elif n_partitions:
+        vds = hl.vds.read_vds(vds_path, n_partitions=n_partitions)
+    else:
+        vds = hl.vds.read_vds(vds_path)
+        if chrom:
+            logger.info("Filtering to chromosome %s...", chrom)
+            vds = hl.vds.filter_chromosomes(vds,keep=chrom)
+
+    # Do note that this comes after filtering to chromosomes. 
+    if naive_coalesce_partitions:
+        vds = hl.vds.VariantDataset(
+            vds.reference_data.naive_coalesce(naive_coalesce_partitions),
+            vds.variant_data.naive_coalesce(naive_coalesce_partitions),
+        )
+
+    if filter_partitions:
+        logger.info("Filtering to %s partitions...", len(filter_partitions))
+        vds = hl.vds.VariantDataset(
+            vds.reference_data._filter_partitions(filter_partitions),
+            vds.variant_data._filter_partitions(filter_partitions),
+        )
+
+    if filter_intervals:
+        logger.info("Filtering to %s intervals...", len(filter_intervals))
+        if isinstance(filter_intervals[0], str):
+            filter_intervals = [
+                hl.parse_locus_interval(x, reference_genome="GRCh38")
+                for x in filter_intervals
+            ]
+        vds = hl.vds.filter_intervals(
+            vds, filter_intervals, split_reference_blocks=split_reference_blocks
+        )
+
+    # Do NOT explicitly worry about chr19:5787204. Unclear if it is a problem in AOU VDS.
+
+    # Filter to specific samples. Stress on this is done upstream and outside of this function.
+    if filter_samples_ht:
+        vds = hl.vds.filter_samples(vds, samples=filter_samples_ht,keep=True)
+
+
+    # Horrible plan: 
+    # n_samples = vmt.count_cols()
+    # filter_variant_ht = filter_variant_ht.annotate_rows(
+        #  recalculated_callrate = filter_variant_ht[f"filter_variant_ht.gvs_{gen_anc.lower()}_an"] / n_samples
+    # )
+
+    # From this point on, we are working with the variant data MT. 
+    # Since we will NOT densify, we do not need to worry about splitting or filtering the reference data.
+    vmt = vds.variant_data
+
+    # Checkpoint before this split is DIFFERENT than checkpointing after this is split. :brain 
+    if split:
+        vmt = _split_and_filter_variant_data_for_loading(
+            vmt, filter_variant_ht, entries_to_keep, checkpoint_before_split=True
+        )
+
+    # Our trusted soruce _split_and_filter_variant_data_for_loading() handles this logic. 
+    # if entries_to_keep is not None:
+    #     vmt = vmt.select_entries(*entries_to_keep)
+
+    if checkpoint_variant_data:
+        vmt = vmt.checkpoint(new_temp_file("vds_loading.variant_data", "mt"))
+
+    return vmt

--- a/v8/analysis/run_ld_from_aou_ld_mt.py
+++ b/v8/analysis/run_ld_from_aou_ld_mt.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""
+Run LD prune / LD matrix / LD score steps from a pre-generated AoU LD MatrixTable.
+
+This script expects an LD-ready MT produced by `generate_ld_data_from_aou_vds.py`
+with entry field `GT` and row fields:
+    - gen_anc_ac
+    - gen_anc_an
+    - gen_anc_af
+    - gen_anc_callrate
+    - gen_anc_freq (from hl.agg.call_stats over GT)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Optional
+
+import hail as hl
+from hail.linalg import BlockMatrix
+from hail.utils.misc import new_temp_file
+
+
+logger = logging.getLogger("aou_ld_from_ld_mt")
+logger.setLevel(logging.INFO)
+
+# Hail scratch (short retention is fine; these are throwaway intermediates).
+TMP_BUCKET = "gs://aou_tmp/ld_marten"
+# Pipeline outputs. MUST match MY_BUCKET in generate_ld_data_from_aou_vds.py, which writes the
+# LD MT this script reads by default.
+MY_BUCKET = "gs://aou_tmp_30_days/ld_marten"
+
+RARE_FREQ = 0.0005
+COMMON_FREQ = 0.005
+
+SINGLETON_AC = 1
+DOUBLETON_AC = 2
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Ensure INFO logs are emitted in Dataproc driver stdout/stderr."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+        stream=sys.stdout,
+        force=True,
+    )
+    logger.setLevel(level)
+
+
+def get_sample_count(mt: hl.MatrixTable, gen_anc: str) -> int:
+    """Single-ancestry run: return cohort sample count for LD score adjustment."""
+    n = mt.count_cols()
+    logger.info("Sample count for %s: %s", gen_anc, n)
+    return n
+
+
+def _paths_ld_pruned(
+    prefix: str,
+    pop: str,
+    ld_contig: str,
+    r2: str,
+    freq: Optional[float],
+    ac_cutoff: Optional[int],
+    adj: bool,
+    custom_suffix: str,
+) -> str:
+    adj_s = "adj" if adj else "noadj"
+    cs = f"_{custom_suffix}" if custom_suffix else ""
+    return (
+        f"{prefix}_pruned_{pop}_{ld_contig}_r2_{r2}_"
+        f"{_filter_mode_token(freq, ac_cutoff)}_{adj_s}{cs}.ht"
+    )
+
+
+def _paths_ld_index(
+    prefix: str,
+    pop: str,
+    ld_contig: str,
+    freq: Optional[float],
+    ac_cutoff: Optional[int],
+    adj: bool,
+    skip_ld_prune: bool,
+    custom_suffix: str,
+) -> str:
+    adj_s = "adj" if adj else "noadj"
+    prune_s = "noprune" if skip_ld_prune else "prunedrop"
+    cs = f"_{custom_suffix}" if custom_suffix else ""
+    return f"{prefix}_index_{pop}_{ld_contig}_{_filter_mode_token(freq, ac_cutoff)}_{adj_s}_{prune_s}{cs}.ht"
+
+
+def _paths_ld_matrix(
+    prefix: str,
+    pop: str,
+    ld_contig: str,
+    freq: Optional[float],
+    ac_cutoff: Optional[int],
+    adj: bool,
+    skip_ld_prune: bool,
+    custom_suffix: str,
+) -> str:
+    adj_s = "adj" if adj else "noadj"
+    prune_s = "noprune" if skip_ld_prune else "prunedrop"
+    cs = f"_{custom_suffix}" if custom_suffix else ""
+    return f"{prefix}_bm_{pop}_{ld_contig}_{_filter_mode_token(freq, ac_cutoff)}_{adj_s}_{prune_s}{cs}.bm"
+
+
+def _paths_ld_scores(
+    prefix: str,
+    pop: str,
+    ld_contig: str,
+    freq: Optional[float],
+    ac_cutoff: Optional[int],
+    adj: bool,
+    skip_ld_prune: bool,
+    custom_suffix: str,
+    call_rate_cutoff: float,
+) -> str:
+    adj_s = "adj" if adj else "noadj"
+    prune_s = "noprune" if skip_ld_prune else "prunedrop"
+    cs = f"_{custom_suffix}" if custom_suffix else ""
+    return (
+        f"{prefix}_ldscores_{pop}_{ld_contig}_{_filter_mode_token(freq, ac_cutoff)}"
+        f"_{adj_s}_{prune_s}_cr{call_rate_cutoff}{cs}.ht"
+    )
+
+
+def _filter_mode_token(freq: Optional[float], ac_cutoff: Optional[int]) -> str:
+    if freq is not None:
+        return f"f{freq}"
+    if ac_cutoff is not None:
+        return f"ac{ac_cutoff}"
+    return "nofilter"
+
+
+def _paths_ld_filtered_mt(
+    prefix: str,
+    pop: str,
+    ld_contig: str,
+    freq: Optional[float],
+    ac_cutoff: Optional[int],
+    adj: bool,
+    custom_suffix: str,
+) -> str:
+    adj_s = "adj" if adj else "noadj"
+    cs = f"_{custom_suffix}" if custom_suffix else ""
+    return f"{prefix}_filteredld_{pop}_{ld_contig}_{_filter_mode_token(freq, ac_cutoff)}_{adj_s}{cs}.mt"
+
+
+def _paths_ld_matrix_input_mt(
+    prefix: str,
+    pop: str,
+    ld_contig: str,
+    freq: Optional[float],
+    ac_cutoff: Optional[int],
+    r2: str,
+    adj: bool,
+    skip_ld_prune: bool,
+    custom_suffix: str,
+) -> str:
+    adj_s = "adj" if adj else "noadj"
+    prune_s = "noprune" if skip_ld_prune else "prunedrop"
+    cs = f"_{custom_suffix}" if custom_suffix else ""
+    return (
+        f"{prefix}_matrix_input_{pop}_{ld_contig}_r2_{r2}_"
+        f"{_filter_mode_token(freq, ac_cutoff)}_{adj_s}_{prune_s}{cs}.mt"
+    )
+
+
+def _filter_rows_for_ld(
+    mt: hl.MatrixTable,
+    freq: Optional[float],
+    ac_cutoff: Optional[int],
+) -> hl.MatrixTable:
+    """
+    Filter rows to LD-eligible variants using post-ADJ cohort callstats (``gen_anc_freq``).
+
+    Symmetric MAF band ``[freq, 1 - freq]`` matches the historical gnomAD-style LD *scores*
+    step in ``OLD_generate_ld_data_from_vds.py`` (previously applied again when reading the
+    index table). We apply it once here so prune, matrix, and scores share the same variant set.
+
+    We intentionally use row-level ``gen_anc_freq`` computed from surviving cohort GT calls so
+    variants with no true observed calls can be excluded before LD.
+    """
+    logger.info(
+        "Starting _filter_rows_for_ld(freq=%s, ac_cutoff=%s)",
+        freq,
+        ac_cutoff,
+    )
+    # Behavior when getting all keys and checking was very odd? 
+    # required = {"gen_anc_freq"}
+    # row_keys = set(mt.row.dtype.keys())
+    # if not required.issubset(row_keys):
+    #     missing = sorted(required - row_keys)
+    #     raise ValueError(
+    #         f"MatrixTable is missing required row fields for LD filtering: {missing}"
+    #     )
+
+    af = mt.gen_anc_freq.AF[1]
+    ac = mt.gen_anc_freq.AC[1]
+    an = mt.gen_anc_freq.AN
+    hom_alt = mt.gen_anc_freq.homozygote_count[1]
+    cond_expr = (an - ac > 1) & ~((af == 0.5) & (hom_alt == 0))
+    if ac_cutoff is not None:
+        cond_expr = cond_expr & (ac > ac_cutoff)
+    if freq is not None:
+        cond_expr = cond_expr & (af >= freq) & (af <= 1 - freq)
+    return mt.filter_rows(cond_expr)
+
+
+def filter_mt_for_ld(
+    mt: hl.MatrixTable,
+    freq: Optional[float] = None,
+    ld_pruned_path: Optional[str] = None,
+    ac_cutoff: Optional[int] = None,
+) -> hl.MatrixTable:
+    logger.info("Starting filter_mt_for_ld")
+    logger.info(
+        "filter_mt_for_ld: freq=%s ac_cutoff=%s ld_pruned_path=%s",
+        freq,
+        ac_cutoff,
+        ld_pruned_path,
+    )
+
+    if ld_pruned_path:
+        # ``hl.ld_prune`` returns a maximal LD-*independent* set (one representative per correlated
+        # cluster). We **exclude** those representatives from the LD matrix so downstream LD uses
+        # variants that remain in dense / correlated regions (related variants), not the tag SNPs.
+        logger.info("Excluding LD-prune independent representatives from %s", ld_pruned_path)
+        ld_ht = hl.read_table(ld_pruned_path)
+        mt = mt.filter_rows(~hl.is_defined(ld_ht[mt.row_key]))
+
+    mt = _filter_rows_for_ld(
+        mt,
+        freq=freq,
+        ac_cutoff=ac_cutoff,
+    )
+    logger.info("filter_mt_for_ld: %s variants, %s samples", *mt.count())
+    return mt
+
+
+def generate_ld_pruned_set(
+    mt: hl.MatrixTable,
+    gen_anc: str,
+    r2: str,
+    freq: Optional[float],
+    radius: int,
+    overwrite: bool,
+    ld_contig: str,
+    ac_cutoff: Optional[int],
+    adj: bool,
+    custom_suffix: str,
+    output_prefix: str,
+) -> None:
+    logger.info(
+        "Starting generate_ld_pruned_set(gen_anc=%s, ld_contig=%s, r2=%s, freq=%s, radius=%s)",
+        gen_anc,
+        ld_contig,
+        r2,
+        freq,
+        radius,
+    )
+    # ``mt`` is expected to be pre-filtered once per contig in ``main``.
+    logger.info("Select rows, cols, and globals, then massively naive coelasce to 25 partitions, before ld_prune")
+    mt_temp = mt.select_rows().select_cols().select_globals()
+    mt_temp = mt_temp.naive_coalesce(25).checkpoint(new_temp_file("ld_set_super_coalesce", "mt"))
+    pruned_ht = hl.ld_prune(mt_temp.GT, r2=float(r2), bp_window_size=radius)
+    ht = mt_temp.rows()
+    # Rows in ``pruned_ht`` are LD-*independent* representatives; we persist them so the matrix
+    # step can **drop** those rows and retain correlated (related) variants for LD.
+    ht = ht.filter(hl.is_defined(pruned_ht[ht.key]))
+    out = _paths_ld_pruned(
+        output_prefix, gen_anc, ld_contig, r2, freq, ac_cutoff, adj, custom_suffix
+    )
+    logger.info("Writing LD pruned set to %s", out)
+    ht.write(out, overwrite)
+
+
+def generate_ld_matrix(
+    mt: hl.MatrixTable,
+    gen_anc: str,
+    radius: int,
+    freq: Optional[float],
+    adj: bool,
+    overwrite: bool,
+    ld_contig: str,
+    r2: str,
+    custom_suffix: str,
+    ac_cutoff: Optional[int],
+    skip_ld_prune: bool,
+    output_prefix: str,
+    ld_block_size: int = 2048,
+) -> None:
+    logger.info(
+        "Starting generate_ld_matrix(gen_anc=%s, ld_contig=%s, r2=%s, freq=%s, radius=%s, "
+        "ld_block_size=%s)",
+        gen_anc,
+        ld_contig,
+        r2,
+        freq,
+        radius,
+        ld_block_size,
+    )
+    # ``mt`` is expected to be pre-filtered once per contig in ``main``.
+    if skip_ld_prune:
+        logger.info("Skipping LD-prune row exclusion before matrix construction (--skip-ld-prune)")
+    else:
+        pruned_path = _paths_ld_pruned(
+            output_prefix, gen_anc, ld_contig, r2, freq, ac_cutoff, adj, custom_suffix
+        )
+        ld_ht = hl.read_table(pruned_path)
+        mt = mt.filter_rows(~hl.is_defined(ld_ht[mt.row_key]))
+    logger.info("Checkpoint MT before ld_matrix")
+    mt = mt.checkpoint(
+        _paths_ld_matrix_input_mt(
+            output_prefix, gen_anc, ld_contig, freq, ac_cutoff, r2, adj, skip_ld_prune, custom_suffix
+        ),
+        overwrite=overwrite,
+    )
+    idx_path = _paths_ld_index(
+        output_prefix, gen_anc, ld_contig, freq, ac_cutoff, adj, skip_ld_prune, custom_suffix
+    )
+    logger.info("Writing LD variant index %s", idx_path)
+    mt.rows().add_index().write(idx_path, overwrite)
+
+    ld = hl.ld_matrix(
+        mt.GT.n_alt_alleles(), mt.locus, radius, block_size=ld_block_size
+    )
+    ld = ld.sparsify_triangle()
+    bm_path = _paths_ld_matrix(
+        output_prefix, gen_anc, ld_contig, freq, ac_cutoff, adj, skip_ld_prune, custom_suffix
+    )
+    logger.info("Writing LD BlockMatrix %s", bm_path)
+    ld.write(bm_path, overwrite)
+
+
+def compute_and_annotate_ld_score(
+    ht: hl.Table, r2_adj: BlockMatrix, radius: int, out_name: str, overwrite: bool
+) -> None:
+    logger.info(
+        "Starting compute_and_annotate_ld_score(out_name=%s, radius=%s)",
+        out_name,
+        radius,
+    )
+    starts_and_stops = hl.linalg.utils.locus_windows(ht.locus, radius, _localize=False)
+    r2_adj = r2_adj._sparsify_row_intervals_expr(starts_and_stops, blocks_only=False)
+    l2row = r2_adj.sum(axis=0).T
+    l2col = r2_adj.sum(axis=1)
+    l2 = l2row + l2col - 1
+    l2_bm_tmp = new_temp_file()
+    l2_tsv_tmp = new_temp_file()
+    l2.write(l2_bm_tmp, force_row_major=True)
+    BlockMatrix.export(l2_bm_tmp, l2_tsv_tmp)
+    ht_scores = hl.import_table(l2_tsv_tmp, no_header=True, impute=True)
+    ht_scores = ht_scores.add_index().rename({"f0": "ld_score"})
+    ht_scores = ht_scores.key_by("idx")
+    ht = ht.annotate(**ht_scores[ht.new_idx]).select_globals()
+    ht.filter(hl.is_defined(ht.ld_score)).write(out_name, overwrite)
+
+
+def generate_ld_scores_from_ld_matrix(
+    gen_anc: str,
+    n_samples: int,
+    freq: Optional[float],
+    ac_cutoff: Optional[int],
+    call_rate_cutoff: float,
+    adj: bool,
+    skip_ld_prune: bool,
+    radius: int,
+    overwrite: bool,
+    ld_contig: str,
+    custom_suffix: str,
+    output_prefix: str,
+) -> None:
+    logger.info(
+        "Starting generate_ld_scores_from_ld_matrix(gen_anc=%s, ld_contig=%s, n_samples=%s, "
+        "freq=%s, radius=%s)",
+        gen_anc,
+        ld_contig,
+        n_samples,
+        freq,
+        radius,
+    )
+    if n_samples < 3:
+        raise ValueError(
+            f"LD score adjustment uses (n-1)/(n-2) with n=columns; need n>=3, got n={n_samples}. "
+            "Use a larger cohort or run with --generate-ld-pruned-set / --generate-ld-matrix only."
+        )
+
+    idx_path = _paths_ld_index(
+        output_prefix, gen_anc, ld_contig, freq, ac_cutoff, adj, skip_ld_prune, custom_suffix
+    )
+    ht = hl.read_table(idx_path)
+
+    row_keys = set(ht.row.dtype.keys())
+    if "idx" not in row_keys:
+        raise ValueError("LD index HT must contain an 'idx' column from add_index().")
+
+    # ``idx`` = matrix row id when the LD BlockMatrix was built (use for ``BlockMatrix.filter``).
+    # ``new_idx`` = dense 0..n-1 over the current table after any optional future filters; use in
+    # ``compute_and_annotate_ld_score`` to align exported score rows. Apply any future ``ht.filter``
+    # *before* ``add_index(new_idx)``. No extra filters here yet.
+    ht = ht.add_index(name="new_idx")
+    indices = ht.idx.collect()
+
+    bm_path = _paths_ld_matrix(
+        output_prefix, gen_anc, ld_contig, freq, ac_cutoff, adj, skip_ld_prune, custom_suffix
+    )
+    r2 = BlockMatrix.read(bm_path)
+    r2 = r2.filter(indices, indices) ** 2
+    r2_adj = ((n_samples - 1.0) / (n_samples - 2.0)) * r2 - (1.0 / (n_samples - 2.0))
+
+    out_name = _paths_ld_scores(
+        output_prefix, gen_anc, ld_contig, freq, ac_cutoff, adj, skip_ld_prune, custom_suffix, call_rate_cutoff
+    )
+    logger.info("Writing LD scores to %s", out_name)
+    compute_and_annotate_ld_score(ht, r2_adj, radius, out_name, overwrite)
+
+
+def main(args) -> None:
+    configure_logging()
+    gen_anc = args.gen_anc
+    contig = args.contig
+    if args.test and not contig:
+        contig = "chr22"
+
+    if args.batch:
+        hl.init(
+            backend="batch",
+            tmp_dir=args.tmp_dir,
+            driver_memory="highmem",
+            driver_cores=8,
+            worker_memory="standard",
+            worker_cores=8,
+            default_reference="GRCh38",
+            log="/aou_ld_from_ld_mt.log",
+            app_name="aou_ld_from_ld_mt",
+            gcs_requester_pays_configuration=args.requester_pays,
+        )
+    elif args.dataproc:
+        hl.init(
+            tmp_dir=args.tmp_dir,
+            default_reference="GRCh38",
+            app_name="aou_ld_from_ld_mt_sas22",
+            gcs_requester_pays_configuration=args.requester_pays,
+            backend="spark",
+        )
+    else:
+        raise ValueError("Must run in batch or dataproc mode. Please set --batch or --dataproc.")
+
+    hl._set_flags(use_new_shuffle="1")
+
+    output_prefix = args.output_prefix or f"{MY_BUCKET}/{gen_anc}_{contig or 'genome'}_vdsld"
+    custom_suffix = args.custom_suffix or ""
+    suffix_token = f"_{custom_suffix}" if custom_suffix else ""
+    ld_mt_path = args.ld_mt_path or f"{output_prefix}_ld_cohort{suffix_token}.mt"
+    if args.coalesce is not None and args.repartition is not None:
+        raise ValueError("Please set only one of --coalesce or --repartition.")
+    if args.ld_freq is None and args.ld_ac is None:
+        raise ValueError("Set at least one of --ld-freq or --ld-ac.")
+
+    logger.info("Reading LD MatrixTable from %s", ld_mt_path)
+    mt = hl.read_matrix_table(ld_mt_path)
+
+    run_ld_steps = (
+        args.generate_ld_pruned_set
+        or args.generate_ld_matrix
+        or args.generate_ld_scores
+    )
+    if not run_ld_steps:
+        logger.info("LD prune/matrix/scores not requested; done.")
+        return
+
+    n_samples = get_sample_count(mt, gen_anc)
+
+    # Fixed chromosome order only (no ``aggregate_rows`` / ``collect_as_set`` over the full MT:
+    # that is too slow at AoU scale). Pass ``--contig`` when the MT is single-chromosome or you
+    # want to avoid iterating absent chromosomes.
+    contig_list = (
+        [f"chr{i}" for i in range(1, 23)] + ["chrX", "chrY"] if not contig else [contig]
+    )
+
+    for ld_contig in contig_list:
+        mt_ld = mt.filter_rows(mt.locus.contig == ld_contig)
+
+        if args.coalesce is not None:
+            logger.info(
+                "Naively coalescing LD MT for %s to %s partitions",
+                ld_contig,
+                args.coalesce,
+            )
+            mt_ld = mt_ld.naive_coalesce(args.coalesce)
+            mt_ld = mt_ld.checkpoint(new_temp_file("naive_coalesced", "mt"))
+        elif args.repartition is not None:
+            logger.info(
+                "Repartitioning LD MT for %s to %s partitions",
+                ld_contig,
+                args.repartition,
+            )
+            # Shuffle is needed to enforce uniform partitions. 
+            mt_ld = mt_ld.repartition(args.repartition, shuffle=True)
+            mt_ld = mt_ld.checkpoint(new_temp_file("repartitioned", "mt"))
+
+
+        if mt_ld.count_rows() == 0:
+            logger.info("Skipping %s: no variants in LD MT for this contig.", ld_contig)
+            continue
+
+        # Bool for whether we need to generate the filtered LD MT
+        need_ld_filtered_mt = args.generate_ld_pruned_set or args.generate_ld_matrix
+        mt_ld_filtered = None
+        if need_ld_filtered_mt:
+            logger.info("Filtering LD MT once for prune/matrix reuse on %s", ld_contig)
+            # Perform the act of filtering the LD MT for the first time.
+            mt_ld_filtered = filter_mt_for_ld(
+                mt=mt_ld,
+                freq=args.ld_freq,
+                ld_pruned_path=None,
+                ac_cutoff=args.ld_ac,
+            )
+            # Path for the filtered LD MT
+            filtered_mt_path = _paths_ld_filtered_mt(
+                output_prefix, gen_anc, ld_contig, args.ld_freq, args.ld_ac, args.adj, custom_suffix
+            )
+            logger.info("Checkpoint filtered LD MT to %s", filtered_mt_path)
+            mt_ld_filtered = mt_ld_filtered.checkpoint(filtered_mt_path, overwrite=args.overwrite)
+
+        if args.skip_ld_prune and args.generate_ld_pruned_set:
+            logger.info(
+                "Skipping --generate-ld-pruned-set for %s due to --skip-ld-prune",
+                ld_contig,
+            )
+        elif args.generate_ld_pruned_set:
+            generate_ld_pruned_set(
+                mt=mt_ld_filtered,
+                gen_anc=gen_anc,
+                r2=args.r2,
+                freq=args.ld_freq,
+                radius=args.radius,
+                overwrite=args.overwrite,
+                ld_contig=ld_contig,
+                ac_cutoff=args.ld_ac,
+                adj=args.adj,
+                custom_suffix=custom_suffix,
+                output_prefix=output_prefix,
+            )
+        if args.generate_ld_matrix:
+            generate_ld_matrix(
+                mt=mt_ld_filtered,
+                gen_anc=gen_anc,
+                radius=args.radius,
+                freq=args.ld_freq,
+                adj=args.adj,
+                overwrite=args.overwrite,
+                ld_contig=ld_contig,
+                r2=args.r2,
+                custom_suffix=custom_suffix,
+                ac_cutoff=args.ld_ac,
+                skip_ld_prune=args.skip_ld_prune,
+                output_prefix=output_prefix,
+                ld_block_size=args.ld_block_size,
+            )
+        if args.generate_ld_scores:
+            generate_ld_scores_from_ld_matrix(
+                gen_anc=gen_anc,
+                n_samples=n_samples,
+                freq=args.ld_freq,
+                ac_cutoff=args.ld_ac,
+                call_rate_cutoff=args.min_call_rate,
+                adj=args.adj,
+                skip_ld_prune=args.skip_ld_prune,
+                radius=args.radius,
+                overwrite=args.overwrite,
+                ld_contig=ld_contig,
+                custom_suffix=custom_suffix,
+                output_prefix=output_prefix,
+            )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="AoU LD: run prune/matrix/scores from a precomputed LD MT")
+    parser.add_argument("--gen-anc", default="eas", help="Cohort ancestry label for naming and score correction")
+    parser.add_argument("--contig", default=None, help="Restrict to one chrom (e.g. chr22)")
+    parser.add_argument(
+        "--output-prefix",
+        default=None,
+        help="Prefix for pruned/index/bm/ldscores paths and default LD MT name",
+    )
+    parser.add_argument(
+        "--ld-mt-path",
+        default=None,
+        help="Path to pre-generated cohort LD MatrixTable",
+    )
+    parser.add_argument(
+        "--min-call-rate",
+        dest="min_call_rate",
+        type=float,
+        default=0.90,
+        help=(
+            "Used in LD-score output path tokens only; row filtering uses symmetric MAF and AC."
+        ),
+    )
+    parser.add_argument(
+        "--generate-ld-pruned-set",
+        action="store_true",
+        help="Write LD-pruned variant HT (before --generate-ld-matrix)",
+    )
+    parser.add_argument(
+        "--skip-ld-prune",
+        action="store_true",
+        help="Skip hl.ld_prune and do not require/read LD-pruned HT for matrix construction.",
+    )
+    parser.add_argument("--generate-ld-matrix", action="store_true")
+    parser.add_argument("--generate-ld-scores", action="store_true")
+    parser.add_argument("--r2", default="0.2", help="ld_prune r^2 threshold")
+    parser.add_argument("--radius", type=int, default=1_000_000, help="LD window (bp)")
+    parser.add_argument(
+        "--ld-freq",
+        type=float,
+        default=None,
+        help="AF lower bound for LD filters (can be combined with --ld-ac).",
+    )
+    parser.add_argument(
+        "--ld-ac",
+        type=int,
+        default=None,
+        help="AC lower bound for LD filters (can be combined with --ld-freq).",
+    )
+    
+    parser.add_argument(
+        "--adj",
+        action="store_true",
+        help="Tag outputs as adj-mode (input MT should already reflect adj filtering).",
+    )
+    parser.add_argument(
+        "--ld-block-size",
+        type=int,
+        default=2048,
+        help="hl.ld_matrix block_size",
+    )
+    parser.add_argument("--custom-suffix", default="", help="Suffix token in output paths")
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--dataproc", action="store_true")
+    parser.add_argument("--batch", action="store_true", help="Run in QueryOnBatch, not Dataproc.")
+    parser.add_argument("--test", action="store_true", help="Use chr22 if --contig not set")
+    parser.add_argument("--tmp-dir", default=TMP_BUCKET)
+    parser.add_argument(
+        "--requester-pays",
+        default="aou-neale-gwas",
+        help="GCS requester pays project",
+    )
+    parser.add_argument(
+        "--coalesce",
+        type=int,
+        default=None,
+        help="Naively coalesce per-contig LD MT to N partitions before downstream steps.",
+    )
+    parser.add_argument(
+        "--repartition",
+        type=int,
+        default=None,
+        help="Repartition per-contig LD MT to N partitions before downstream steps.",
+    )
+    cli_args = parser.parse_args()
+    main(cli_args)


### PR DESCRIPTION
Two-step pipeline for per-ancestry LD from the AoU v8 short-read WGS VDS.

- generate_vat_for_ld.py: build the VAT variant-filter table, either genome-wide (--mode single) or one table per contig (--mode serial, resumable via --reuse-existing, optionally combined with --union)
- generate_ld_data_from_aou_vds.py: step 1, VDS variant_data -> hom-ref-filled LD-ready cohort MatrixTable
- run_ld_from_aou_ld_mt.py: step 2, LD prune / matrix / scores from that MT
- ld_methods.py: shared VAT processing and VDS variant_data loading

Biggest note is the implementation of fill_missing_gt_hom_ref() in generate_ld_data_from_aou_vds.py. 

Also, note that there are cost savings to be made in how MTs are written out per-chromosome per-genetic ancestry group. Writing these with fewer larger jobs may be more efficient in Hail Batch. 